### PR TITLE
fix: swap X_mix_w_out/X_tank_w_out column assignments in electric boiler postprocess

### DIFF
--- a/src/enex_analysis/eb_pv_ess.py
+++ b/src/enex_analysis/eb_pv_ess.py
@@ -119,5 +119,5 @@ class EB_PV_ESS(ElectricBoiler):
             df["X_tot_sys [W]"] += df["X_uv [W]"].fillna(0)
         df["Xc_sys_tot [W]"] = df.filter(regex=r"^Xc_").sum(axis=1)
         df["cop_grid [-]"] = df["Q_tank_w_out [W]"] / df["E_grid_import [W]"].replace(0, np.nan)
-        df["ex_eff_sys [-]"] = (df["Xst_tank [W]"] + df["X_tank_w_out [W]"]) / df["X_tot_sys [W]"].replace(0, np.nan)
+        df["ex_eff_sys [-]"] = (df["Xst_tank [W]"] + df["X_mix_w_out [W]"]) / df["X_tot_sys [W]"].replace(0, np.nan)
         return df

--- a/src/enex_analysis/electric_boiler.py
+++ b/src/enex_analysis/electric_boiler.py
@@ -309,10 +309,10 @@ class ElectricBoiler:
 
         df["Q_tank_w_out [W]"] = G_mix_out * (cu.C2K(df["T_mix_w_out [°C]"]) - self.T_sup_w_K)
 
-        df["X_mix_w_out [W]"] = calc_exergy_flow(G_tank_w_out, T_tank_K, T0_K)
+        df["X_tank_w_out [W]"] = calc_exergy_flow(G_tank_w_out, T_tank_K, T0_K)
         df["X_tank_w_in [W]"] = calc_exergy_flow(G_tank_w_in, self.T_tank_w_in_K, T0_K)
         df["X_mix_sup_w_in [W]"] = calc_exergy_flow(G_mix_sup_w, self.T_sup_w_K, T0_K)
-        df["X_tank_w_out [W]"] = calc_exergy_flow(G_mix_out, cu.C2K(df["T_mix_w_out [°C]"]), T0_K)
+        df["X_mix_w_out [W]"] = calc_exergy_flow(G_mix_out, cu.C2K(df["T_mix_w_out [°C]"]), T0_K)
 
         # Totals
         X_tot = df["E_heater [W]"].fillna(0)
@@ -331,14 +331,14 @@ class ElectricBoiler:
         X_in_tank = X_in_tank + X_sub_in_tank_add
 
         X_out_tank = df["X_tank_loss [W]"] + df["Xst_tank [W]"]
-        if "X_mix_w_out [W]" in df.columns:
-            X_out_tank = X_out_tank + df["X_mix_w_out [W]"].fillna(0)
+        if "X_tank_w_out [W]" in df.columns:
+            X_out_tank = X_out_tank + df["X_tank_w_out [W]"].fillna(0)
         X_out_tank = X_out_tank + X_sub_out_tank_add
 
         df["Xc_tank [W]"] = X_in_tank - X_out_tank
 
         # Efficiency
-        df["X_eff_sys [-]"] = df["X_tank_w_out [W]"].fillna(0) / df["X_tot [W]"].replace(0, np.nan)
+        df["X_eff_sys [-]"] = df["X_mix_w_out [W]"].fillna(0) / df["X_tot [W]"].replace(0, np.nan)
 
         return df
 


### PR DESCRIPTION
## 요약

#8 에서 진단된 `ElectricBoiler._postprocess`의 컬럼 스왑 버그를 수정한다. `X_mix_w_out [W]`와 `X_tank_w_out [W]`의 값 할당을 스트림 정의(`_calc_tank_flow_context`)에 맞게 바로잡고, 두 컬럼을 참조하던 `Xc_tank`(electric_boiler.py) / `ex_eff_sys`(eb_pv_ess.py)도 값이 그대로 유지되도록 참조를 함께 갱신했다.

## 검증

동절기 대표일(Annex 42 4/7 DHW × 200 L 탱크, `Seoul_250101_T0.csv`, T_sup=10°C, T_serv=40°C, 2일 spin-up 후 마지막 하루)로 수정 전/후를 비교:

| 지표 | 수정 전 (버그) | 수정 후 |
| --- | --- | --- |
| `Xc_mix` 일합계 | **-0.1610 kWh** (2법칙 위반) | **+0.1766 kWh** |
| `Xc_mix` 최소 timestep / 음수 개수 | -462.78 W / 48건 | 0.0 W / 0건 |
| `Xc_tank` 일합계 | 7.9705 kWh | 7.9705 kWh (불변) |
| `X_tot` 일합계 | 9.0000 kWh | 9.0000 kWh (불변) |
| `X_eff_sys` 평균 | 0.010020 | 0.010020 (불변) |

`Xc_tank`·`X_tot`·`X_eff_sys`가 수정 전후 완전히 동일하다는 것은, 이번 수정이 두 컬럼의 **이름**만 값과 일치하도록 바로잡았을 뿐 다른 물리량에는 회귀가 없음을 보여준다. `eb_pv_ess.py`(`EB_PV_ESS`)는 import·컴파일 확인만 수행(별도 PV/ESS 통합 시나리오 재현은 범위 밖).

## Test plan

- [x] 수정 전/후 스크립트로 동절기 대표일 재계산 — 표 참조
- [x] `Xc_mix` 전 timestep ≥ 0 확인 (0건 음수)
- [x] `Xc_tank`/`X_tot`/`X_eff_sys` 수치 불변 확인 (회귀 없음)
- [x] `py_compile` + `EB_PV_ESS` import 확인

Closes #8
