### PR TITLE
ci: self-hosted 러너(ml-main)로 이전

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   build-and-deploy:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, ml-main]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
CI/CD 를 self-hosted 러너 `ml-main` 에서 실행하는 방침에 맞춰 워크플로를 이전한다. GitHub-hosted 러너는 분 과금에 걸려 job 이 시작조차 되지 않는다(step 0개로 즉시 실패).

### 변경

- `.github/workflows/docs.yml (runs-on x1)`

### 러너 환경 주의

ml-main 에는 **passwordless sudo 가 없다.** `sudo apt-get install` 스텝이 있던 워크플로는 설치 대신 **존재 검증**으로 바꿨다 — 필요한 패키지(graphviz, Noto CJK/emoji 폰트)는 러너에 이미 설치돼 있고, 검증 스텝이 누락을 즉시 실패로 잡는다.

### 검증

- 변환 후 전 파일 `yaml.safe_load` 파싱 OK, 모든 job 의 `runs-on` 이 `[self-hosted, ml-main]` 인지 확인
- 이 PR 의 체크가 ml-main 에서 도는 것 자체가 이전의 검증이다
